### PR TITLE
Better CLI performance

### DIFF
--- a/bin/donejs
+++ b/bin/donejs
@@ -13,7 +13,9 @@ var mypkg = require(path.join(__dirname, '..', 'package.json'));
 var commandList = ['init', 'generate'];
 var listSeparator = '\n\t• ';
 var initDescription = 'Initialize a new DoneJS application in a new folder or the current one';
-var generatorDescription = 'No generators available.';
+var generators = mypkg.donejs.generators;
+var generatorDescription = 'Run a generator. Available generators:' +
+  listSeparator + generators.join(listSeparator);
 
 program.version(mypkg.version)
   .description("The DoneJS command line utility lets you run generators, NPM scripts and binaries local to your project.");
@@ -49,7 +51,7 @@ utils.projectRoot().then(function (root) {
       program.help();
     },
     add: function(name, params) {
-      if(generators && generators[name]) {
+      if(generators.indexOf(name) !== -1) {
         return actions.generate(name, params);
       }
       log(utils.add(path.join(root, 'node_modules'), name, params));
@@ -61,15 +63,6 @@ utils.projectRoot().then(function (root) {
     curpkg = require(path.join(root, 'package.json'));
   } catch (e) {
     // otherwise no local package.json
-  }
-
-  try {
-    generators = require(path.join(root, 'node_modules', 'generator-donejs'));
-    generatorDescription = 'Run a generator. Available generators:';
-    generatorDescription += listSeparator +
-    Object.keys(generators).join(listSeparator);
-  } catch (e) {
-    // We can do this because `generatorDescription` is already set
   }
 
   // donejs init

--- a/bin/donejs
+++ b/bin/donejs
@@ -4,6 +4,7 @@ var path = require('path');
 var fs = require('fs');
 var program = require('commander');
 var mkdirp = require('mkdirp');
+var debug = require('debug')('donejs-cli:binary');
 
 var utils = require('../lib/utils');
 var log = utils.log;
@@ -11,19 +12,18 @@ var log = utils.log;
 var mypkg = require(path.join(__dirname, '..', 'package.json'));
 
 var commandList = ['init', 'generate'];
-var listSeparator = '\n\t• ';
 var initDescription = 'Initialize a new DoneJS application in a new folder or the current one';
-var generators = mypkg.donejs.generators;
-var generatorDescription = 'Run a generator. Available generators:' +
-  listSeparator + generators.join(listSeparator);
 
 program.version(mypkg.version)
-  .description("The DoneJS command line utility lets you run generators, NPM scripts and binaries local to your project.");
+  .description('The DoneJS command line utility lets you run generators, NPM scripts and binaries local to your project.');
+
+debug('Loading CLI, version is', mypkg.version);
 
 utils.projectRoot().then(function (root) {
-  var generators = null;
+  debug('Found project root', root);
   var actions = {
     init: function (folder) {
+      debug('Initializing new application', folder);
       if (folder) {
         var appDir = path.join(process.cwd(), folder);
         if (fs.existsSync(appDir)) {
@@ -37,6 +37,7 @@ utils.projectRoot().then(function (root) {
       }
 
       root = path.join(process.cwd(), 'node_modules');
+      debug('Generating application in folder', root);
       log(utils.generate(root, 'generator-donejs', ['app', {
           version: mypkg.version,
           packages: mypkg.donejs
@@ -44,6 +45,7 @@ utils.projectRoot().then(function (root) {
       ]));
     },
     generate: function (type, options) {
+      debug('Generating', 'generator-donejs', type, options);
       log(utils.generate(path.join(root, 'node_modules'), 'generator-donejs', [[type].concat(options)]));
     },
     catchAll: function (command) {
@@ -51,9 +53,13 @@ utils.projectRoot().then(function (root) {
       program.help();
     },
     add: function(name, params) {
-      if(generators.indexOf(name) !== -1) {
+      var generators = require(path.join(root, 'node_modules', 'generator-donejs'));
+      if(generators[name]) {
+        debug('add called but running generate instead', name, params);
         return actions.generate(name, params);
       }
+
+      debug('add', name, params);
       log(utils.add(path.join(root, 'node_modules'), name, params));
     }
   };
@@ -63,6 +69,7 @@ utils.projectRoot().then(function (root) {
     curpkg = require(path.join(root, 'package.json'));
   } catch (e) {
     // otherwise no local package.json
+    debug('Could not load local package.json');
   }
 
   // donejs init
@@ -72,7 +79,7 @@ utils.projectRoot().then(function (root) {
 
   // donejs generate
   program.command('generate <name> [options...]')
-    .description(generatorDescription)
+    .description('Run a generator.')
     .action(actions.generate);
 
   // catchall
@@ -90,6 +97,7 @@ utils.projectRoot().then(function (root) {
       program.command(script + ' [...args]')
         .description('`' + curpkg.scripts[script] + '` (package.json)')
         .action(function (args) {
+          debug('Running script', script, args);
           log(utils.runScript(script, args));
         });
     }
@@ -104,6 +112,7 @@ utils.projectRoot().then(function (root) {
         program.command(name + ' [...args]')
           .description('')
           .action(function (args) {
+            debug('Running command', name, args);
             log(utils.runCommand(path.join(binPath, name), args));
           });
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,22 +1,24 @@
 var Q = require('q');
 var path = require('path');
 var npm = require('npm');
-var exec = require('child_process').exec;
+var fs = require('fs');
 var spawn = require('cross-spawn-async');
 var yeoman = require('yeoman-environment');
 
+// Returns the NPM root
 exports.projectRoot = function() {
-    var deferred = Q.defer(),
-        child = exec("npm prefix");
+  var root = process.cwd();
+  var current = root;
 
-    child.stdout.on("data", function(data) {
-        deferred.resolve(data.trim());
-    });
-    child.on("close", function(code) {
-        if (code) { deferred.reject(code); }
-    });
+  while(current && !fs.existsSync(path.join(current, 'package.json')) ) {
+    if(current !== path.dirname(current)) {
+      return Q(root);
+    }
 
-    return deferred.promise;
+    current = path.dirname(current);
+  }
+
+  return Q(current || root);
 };
 
 // Returns a .then-able function that installs a single module

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 var Q = require('q');
+var debug = require('debug')('donejs-cli:utils');
 var path = require('path');
 var npm = require('npm');
 var fs = require('fs');
@@ -12,13 +13,15 @@ exports.projectRoot = function() {
 
   while(current && !fs.existsSync(path.join(current, 'package.json')) ) {
     if(current !== path.dirname(current)) {
+      debug('Returning cwd project root', root);
       return Q(root);
     }
 
     current = path.dirname(current);
   }
 
-  return Q(current || root);
+  debug('Found project root', current);
+  return Q(current);
 };
 
 // Returns a .then-able function that installs a single module
@@ -28,7 +31,7 @@ var installIfMissing = exports.installIfMissing = function(root, module) {
   if(!module) {
     module = root;
   }
-
+  debug('Looking for and installing if missing', module);
   return function (previous) {
     try {
       require.resolve(location);
@@ -74,6 +77,7 @@ var generate = exports.generate = function(root, generator, args) {
 
       Object.keys(generators).forEach(function(name) {
           var fullName = path.join(root, generator, name);
+          debug('Registering generator', fullName);
           env.register(require.resolve(fullName), name);
       });
 
@@ -86,11 +90,13 @@ exports.add = function(root, name, params) {
   var generatorName = 'donejs-' + name;
   params = (params && params.length) ? params : ['default'];
 
+  debug('Adding', generatorName, params);
   return generate(root, generatorName, params);
 };
 
 exports.runScript = function(name, args) {
-  return runCommand("npm", ['run', name].concat(args || []));
+  debug('Running npm script', name, args);
+  return runCommand('npm', ['run', name].concat(args || []));
 };
 
 // Log error messages and exit application

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "cross-spawn-async": "^2.0.0",
+    "debug": "^2.2.0",
     "mkdirp": "^0.5.1",
     "npm": "^2.13.1",
     "q": "^1.4.1",
@@ -49,7 +50,6 @@
     "yeoman-generator": "^0.20.3"
   },
   "donejs": {
-    "generators": [ "app", "component", "supermodel" ],
     "dependencies": {
       "can": "^2.3.0",
       "can-connect": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "yeoman-generator": "^0.20.3"
   },
   "donejs": {
+    "generators": [ "app", "component", "supermodel" ],
     "dependencies": {
       "can": "^2.3.0",
       "can-connect": "^0.3.0",

--- a/test/utils.js
+++ b/test/utils.js
@@ -83,15 +83,6 @@ describe('DoneJS CLI tests', function() {
         .fail(fail);
     });
 
-    it("get project root", function(done) {
-        var pathFromTest = path.join(process.cwd(), "node_modules");
-        utils.projectRoot().then(function(p) {
-            assert.equal(path.join(p, "node_modules"), pathFromTest);
-            done();
-        })
-        .fail(fail);
-    });
-
 		var runCommandPassesStdio = function(done){
 			var script = __dirname + "/tests/needstty.js";
 			var makeAssert = function(val, msg){
@@ -116,5 +107,30 @@ describe('DoneJS CLI tests', function() {
 			it("runCommand passes stdio for scripts that need a tty", runCommandPassesStdio);
 		}
 
+  });
+
+  describe('project root', function() {
+    it('get project root when it is current folder', function(done) {
+        var pathFromTest = process.cwd();
+        utils.projectRoot().then(function(p) {
+            assert.equal(p, pathFromTest);
+            done();
+        })
+        .fail(done);
+    });
+
+    it('return cwd when there is no package.json anywhere', function(done) {
+        var oldCwd = process.cwd();
+        var newCwd = path.join(process.cwd(), '..');
+
+        process.chdir(newCwd);
+
+        utils.projectRoot().then(function(p) {
+            assert.equal(p, newCwd);
+            process.chdir(oldCwd);
+            done();
+        })
+        .fail(done);
+    });
   });
 });


### PR DESCRIPTION
This improves the CLI by hardcoding the available generators (since we have to update dependency versions manually anyway, this should be fine) and looking up the project root synchronously without having to spawn `npm prefix`. Together with https://github.com/donejs/donejs/pull/320 this should improve CLI performance significantly.