### PR TITLE
Specify npmDependencies in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
       "testee": "^0.2.0",
       "donejs-cli": "^0.5.0"
     }
+  },
+  "system": {
+    "npmDependencies": []
   }
 }


### PR DESCRIPTION
To prevent Steal from trying to load anything from this package. Fixes #5 