### PR TITLE
Warn user when not using a compatible NPM version

### DIFF
--- a/bin/donejs
+++ b/bin/donejs
@@ -43,7 +43,7 @@ utils.projectRoot().then(function (root) {
         return utils.npmVersion().then(function(version){
           // We expect NPM 2.x
           if(version.major !== 2) {
-            console.error('DoneJS current only supports NPM 2.x');
+            console.error('\nWARN: DoneJS current only supports NPM 2.x. You can install it with: npm install -g npm@2.x');
           }
         });
       };

--- a/bin/donejs
+++ b/bin/donejs
@@ -38,11 +38,25 @@ utils.projectRoot().then(function (root) {
 
       root = path.join(process.cwd(), 'node_modules');
       debug('Generating application in folder', root);
-      log(utils.generate(root, 'generator-donejs', ['app', {
+
+      var verifyVersion = function(){
+        return utils.npmVersion().then(function(version){
+          // We expect NPM 2.x
+          if(version.major !== 2) {
+            console.error('DoneJS current only supports NPM 2.x');
+          }
+        });
+      };
+      var generatePromise = utils.generate(root, 'generator-donejs', ['app', {
           version: mypkg.version,
           packages: mypkg.donejs
         }
-      ]));
+      ]).then(verifyVersion, function(err){
+        return verifyVersion().then(function(){
+          throw err;
+        });
+      });
+      log(generatePromise);
     },
     generate: function (type, options) {
       debug('Generating', 'generator-donejs', type, options);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -108,3 +108,28 @@ exports.log = function(promise) {
     process.exit(1);
   });
 };
+
+exports.npmVersion = function(){
+    var child = spawn('npm', ['--version'], {
+    cwd: process.cwd()
+  });
+
+  var deferred = Q.defer();
+  var version = '';
+  var getVersion = function(d){
+    version = d.toString();
+  };
+
+  child.stdout.on('data', getVersion);
+
+  child.on('exit', function() {
+    var parts = version.trim().split(".");
+    deferred.resolve({
+      major: +parts[0],
+      minor: +parts[1],
+      patch: parts[1]
+    });
+  });
+
+  return deferred.promise;
+};

--- a/test/utils.js
+++ b/test/utils.js
@@ -107,6 +107,14 @@ describe('DoneJS CLI tests', function() {
 			it("runCommand passes stdio for scripts that need a tty", runCommandPassesStdio);
 		}
 
+    it("gets the npm version", function(done){
+      utils.npmVersion().then(function(version){
+        assert.equal(typeof version.major, "number", "the major version is a number");
+        assert.equal(typeof version.minor, "number", "the minor version is a number");
+        assert.equal(typeof version.patch, "string", "the patch version is a string");
+      }).then(done, done);
+    });
+
   });
 
   describe('project root', function() {


### PR DESCRIPTION
This adds a warning on `donejs init` if they are using a version of NPM
that is not compatible. Currently we are supporting 2.x, but will add
support for 3.x soon.

**Note** don't merge this yet, I want to review it hard since we don't have tests for `bin/donejs`.