### PR TITLE
Use the newest version of steal

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       "done-css": "~1.1.13",
       "generator-donejs": "^0.3.0",
       "jquery": "^2.1.4",
-      "steal": "0.12.4"
+      "steal": "^0.12.7"
     },
     "devDependencies": {
       "documentjs": "0.3.3",


### PR DESCRIPTION
https://github.com/stealjs/steal/pull/514

Addressed the issues that caused the roll back to 0.12.4. 0.12.7 now how
those fixes and works.