### PR TITLE
Added package.json JSON validation [fixes #12]

### DIFF
--- a/bin/donejs
+++ b/bin/donejs
@@ -10,6 +10,12 @@ var utils = require('../lib/utils');
 var log = utils.log;
 
 var mypkg = require(path.join(__dirname, '..', 'package.json'));
+// Validating package.json for correct JSON syntax.
+try {
+  JSON.parse(mypkg);
+} catch(e) {
+  console.error("Could not load local package.json file. Probably invalid JSON.");
+}
 
 var commandList = ['init', 'generate'];
 var initDescription = 'Initialize a new DoneJS application in a new folder or the current one';


### PR DESCRIPTION
Now, an error message appears if `package.json` file has an error. Example: 

![screen shot 2015-11-28 at 03 30 27](https://cloud.githubusercontent.com/assets/6480910/11449714/8c73f666-9580-11e5-9850-2f347e7f9b8b.png)
