### PR TITLE
Use loglevel error when doing npm install

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,7 +56,7 @@ var installIfMissing = exports.installIfMissing = function(root, module) {
       require.resolve(location);
     } catch (e) {
       console.log('Installing ' + module);
-      return runCommand('npm', ['install', module]).then(function () {
+      return runCommand('npm', ['install', module, '--loglevel', 'error']).then(function () {
         return previous;
       });
     }


### PR DESCRIPTION
This prevent warnings that could scare users into thinking something is
wrong. Part of https://github.com/donejs/donejs/issues/455