### PR TITLE
Add new prelease of steal/steal-tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mocha": "^2.2.5"
   },
   "dependencies": {
+    "can-wait": "^0.2.7",
     "commander": "^2.9.0",
     "cross-spawn-async": "^2.0.0",
     "debug": "^2.2.0",
@@ -59,14 +60,14 @@
       "done-css": "~1.1.13",
       "generator-donejs": "^0.5.0",
       "jquery": "2.1.4",
-      "steal": "^0.13.0"
+      "steal": "^0.14.0-pre.6"
     },
     "devDependencies": {
       "documentjs": "^0.4.1",
       "donejs-deploy": "^0.4.0",
       "funcunit": "~3.0.0",
       "steal-qunit": "^0.1.1",
-      "steal-tools": "^0.13.0",
+      "steal-tools": "^0.14.0-pre.0",
       "testee": "^0.2.4",
       "donejs-cli": "^0.6.0",
       "can-fixture": "^0.1.0"


### PR DESCRIPTION
This is the release that makes progressively loaded package.jsons work,
     will do a donejs pre-release for this.