### PR TITLE
Remove can-wait as a donejs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
       "can": "^2.3.0",
       "can-connect": "^0.3.0",
       "can-ssr": "^0.11.0",
-      "can-wait": "^0.2.7",
       "done-autorender": "^0.6.0",
       "done-component": "^0.4.0",
       "done-css": "~1.1.13",


### PR DESCRIPTION
This is no longer needed because of
https://github.com/donejs/autorender/pull/19