### PR TITLE
Install the correct version of generator-donejs

### DIFF
--- a/bin/donejs
+++ b/bin/donejs
@@ -42,14 +42,21 @@ utils.projectRoot().then(function (root) {
       }
 
       debug('Generating application in folder', process.cwd());
-      
+
       var type = options.type || 'app';
-      var generatePromise = utils.generate(nodeModules, 'generator-donejs', [type, {
-          version: mypkg.version,
-          packages: mypkg.donejs,
-          skipInstall: options.skipInstall
-        }
-      ]);
+      var genVersion = mypkg.donejs.dependencies['generator-donejs'];
+      var genInstallPromise = utils.installIfMissing(nodeModules,
+                                                     'generator-donejs',
+                                                     genVersion)();
+
+      var generatePromise = genInstallPromise.then(function () {
+        return utils.generate(nodeModules, 'generator-donejs', [type, {
+            version: mypkg.version,
+            packages: mypkg.donejs,
+            skipInstall: options.skipInstall
+          }
+        ]);
+      });
       log(generatePromise);
     },
     generate: function (type, options) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,7 +45,7 @@ var runCommand = exports.runCommand = function(cmd, args) {
 
 // Returns a .then-able function that installs a single module
 // if it is not available in the current path
-var installIfMissing = exports.installIfMissing = function(root, module) {
+var installIfMissing = exports.installIfMissing = function(root, module, range) {
   var location = module ? path.join(root, module) : root;
   if(!module) {
     module = root;
@@ -55,6 +55,9 @@ var installIfMissing = exports.installIfMissing = function(root, module) {
     try {
       require.resolve(location);
     } catch (e) {
+      if(range) {
+        module = module + '@' + range;
+      }
       console.log('Installing ' + module);
       return runCommand('npm', ['install', module, '--loglevel', 'error']).then(function () {
         return previous;

--- a/test/utils.js
+++ b/test/utils.js
@@ -22,14 +22,26 @@ describe('DoneJS CLI tests', function () {
       delete global.donejsTestPluginLoaded;
     });
 
-    it('installIfMissing', function (done) {
-      Q.resolve(utils.installIfMissing('day-seconds')())
-      .then(function () {
-        var daySeconds = require('day-seconds');
-        assert.equal(daySeconds(true), 86400, 'day-second module installed and loaded');
-        done();
-      })
-      .fail(fail);
+    describe('installIfMissing', function() {
+      it('Ensures a module is installed', function (done) {
+        Q.resolve(utils.installIfMissing('day-seconds')())
+        .then(function () {
+          var daySeconds = require('day-seconds');
+          assert.equal(daySeconds(true), 86400,
+                       'day-second module installed and loaded');
+          done();
+        })
+        .fail(fail);
+      });
+
+      it('Can install a version range', function (done) {
+        Q.resolve(utils.installIfMissing(testDir, 'foo', '^1.0.0')())
+        .then(function () {
+          assert(require('foo'), 'foo was installed');
+          done();
+        })
+        .fail(fail);
+      });
     });
 
     describe('add', function () {


### PR DESCRIPTION
When installing a new application, generator-donejs is used to provide
the folder structure / files for the project. However we need to use the
version of generator-donejs that matches this version of donejs-cli,
        this way breaking changes of generator-donejs can occur without
        affecting older versions of donejs.

Closes #18