### PR TITLE
Depend on can-zone

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "dependencies": {
       "can": "^2.3.16",
       "can-connect": "^0.4.0-pre.0",
+      "can-zone": "^0.4.4",
       "done-serve": "^0.1.0",
       "done-autorender": "^0.7.3",
       "done-component": "^0.4.0",


### PR DESCRIPTION
With can-zone 0.4.4 we now have `can-zone/register` which registers a
super-dependency for all async things. We need to make this a
configDependency in donejs projects, so we need donejs projects to
directly depend on can-zone.