### PR TITLE
Updated. Deprecated iojs as its part of node >=4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ language: node_js
 before_script:
   - install-engine-dependencies
 node_js:
-  - "0.10"
-  - "0.12"
-  - "node"
-  - "iojs"
-  - "4.0"
+  - 0.10
+  - 0.12
+  - stable
+  - 4.0
 script: npm run coverage:upload


### PR DESCRIPTION
Changed Syntax to yml 
made this trevor compatible for local testing.

ALSO:
DEPRECATED
This image is officially deprecated in favor of the node image. Please adjust your usage accordingly!

See iojs.org for more information, specifically the following note:

io.js has merged with the Node.js project again.
There won't be any further io.js releases. All of the features in io.js are available in Node.js v4 and above.