### PR TITLE
removing documentjs as a dependency of generated apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
       "steal-stache": "^3.0.4"
     },
     "devDependencies": {
-      "documentjs": "^0.4.4",
       "donejs-cli": "^1.0.0-alpha.2",
       "funcunit": "^3.1.0",
       "steal-qunit": "^1.0.0",

--- a/test/tests/get-local-bins-test.js
+++ b/test/tests/get-local-bins-test.js
@@ -19,14 +19,12 @@ describe('getLocalBins', function() {
     process.chdir(binPath);
     fs.writeFileSync('mocha');
     fs.writeFileSync('jshint');
-    fs.writeFileSync('documentjs');
     process.chdir(cwd);
 
     var binaries = getLocalBins(binPath);
 
     assert(binaries.indexOf('mocha') !== -1, 'should include mocha');
     assert(binaries.indexOf('jshint') !== -1, 'should include jshint');
-    assert(binaries.indexOf('documentjs') !== -1, 'should include documentjs');
 
     rimraf.sync(binPath);
   });


### PR DESCRIPTION
This will be handled by donejs-documentjs.

Part of https://github.com/donejs/donejs/issues/784.