### PR TITLE
Upgrade to steal-tools 2.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
       "funcunit": "^3.6.1",
       "steal-conditional": "^1.0.0",
       "steal-qunit": "^1.0.1",
-      "steal-tools": "^2.0.6",
+      "steal-tools": "^2.0.9",
       "testee": "^0.8.1"
     }
   }


### PR DESCRIPTION
This fixes a couple of tree-shaking bugs that are worth ensuring people
get in donejs apps.